### PR TITLE
Switch to default port of 9780

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ password: mypassword
 To run the exporter:
 
 ```console
-$ docker run -v /tmp/hitron_coda.yml:/hitron_coda.yml -p 9779:9779 hairyhenderson/hitron_coda_exporter
+$ docker run -v /tmp/hitron_coda.yml:/hitron_coda.yml -p 9780:9780 hairyhenderson/hitron_coda_exporter
 ...
 ```
 
-Now you can visit http://localhost:9779/scrape to have the exporter scrape
+Now you can visit http://localhost:9780/scrape to have the exporter scrape
 metrics from the device.
 
 To configure Prometheus to scrape from this exporter, use a
@@ -67,7 +67,7 @@ like this one:
     metrics_path: /scrape
     static_configs:
       - targets:
-        - 'localhost:9779'
+        - 'localhost:9780'
 ```
 
 ## License

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	configFile    = kingpin.Flag("config.file", "Path to configuration file.").Default("hitron_coda.yml").String()
-	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9779").String()
+	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9780").String()
 	// dryRun        = kingpin.Flag("dry-run", "Only verify configuration is valid and exit.").Default("false").Bool()
 
 	sc = &safeConfig{


### PR DESCRIPTION
Looks like I missed the boat on `9779` 😅 - no matter, `9780` is just as good!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>